### PR TITLE
Making tickets' custom fields available in the sprints' ticket lists.

### DIFF
--- a/backlog/prefs.py
+++ b/backlog/prefs.py
@@ -8,13 +8,15 @@ from trac.core import *
 from trac.prefs import IPreferencePanelProvider
 from trac.util.translation import _
 from trac.web.chrome import add_notice, ITemplateProvider
+from trac.ticket.api import TicketSystem
 
 class BacklogPluginPrefPanel(Component):
     implements(IPreferencePanelProvider, ITemplateProvider)
 
-    _form_fields = [ 
-        'id', 'summary', 'component', 'version', 'type', 'owner', 'status',
-        'time_created'
+    _ticket_fields = [
+        (u'id', u'Id'), (u'summary', u'Summary'), (u'component', u'Component'),
+        (u'version', u'Version'), (u'type', u'Type'), (u'owner', u'Owner'),
+        (u'status', u'Status'), (u'time_created', u'Created')
     ]
 
     # IPreferencePanelProvider methods
@@ -30,9 +32,11 @@ class BacklogPluginPrefPanel(Component):
             add_notice(req,_('Your backlog preferences have been saved.'))
             req.redirect(req.href.prefs(panel or None))
 
+        custom_fields = [(cf["name"], cf["label"]) for cf in TicketSystem(self.env).get_custom_fields()]
         return 'prefs_backlog.html', {
+            'fields': self._ticket_fields + custom_fields,
             'shown_fields':
-                req.session.get('backlog_fields') or self._form_fields
+                req.session.get('backlog_fields') or [field[0] for field in self._ticket_fields]
         }
 
     # ITemplateProvider methods

--- a/backlog/templates/backlog.html
+++ b/backlog/templates/backlog.html
@@ -248,6 +248,7 @@
                         <th py:if="'owner' in shown_fields">Owner</th>
                         <th py:if="'status' in shown_fields">Status</th>
                         <th py:if="'time_created' in shown_fields">Created</th>
+                        <th py:for="cf in custom_fields">${cf[1]}</th>
                     </tr>
                 </thead>
                 <tbody id="tickets">
@@ -260,6 +261,9 @@
                         <td py:if="'owner' in shown_fields">$ticket.owner</td>
                         <td py:if="'status' in shown_fields">$ticket.status</td>
                         <td py:if="'time_created' in shown_fields">${format_date(ticket.time_created)}</td>
+                        <py:for each="cf in custom_fields">
+                            <td>${ticket[cf[0]]}</td>
+                        </py:for>
                     </tr>
                 </tbody>
             </table>

--- a/backlog/templates/prefs_backlog.html
+++ b/backlog/templates/prefs_backlog.html
@@ -16,29 +16,8 @@
     <body>
         <div class="field">
             <label>Shown Ticket Fields:</label>
-            <label>
-                <input type="checkbox" name="backlog_fields" value="id" checked="${'id' in shown_fields or None}" />Id
-            </label>
-            <label>
-                <input type="checkbox" name="backlog_fields" value="summary" checked="${'summary' in shown_fields or None}" />Summary
-            </label>
-            <label>
-                <input type="checkbox" name="backlog_fields" value="component" checked="${'component' in shown_fields or None}" />Component
-            </label>
-            <label>
-                <input type="checkbox" name="backlog_fields" value="version" checked="${'version' in shown_fields or None}" />Version
-            </label>
-            <label>
-                <input type="checkbox" name="backlog_fields" value="type" checked="${'type' in shown_fields or None}" />Type
-            </label>
-            <label>
-                <input type="checkbox" name="backlog_fields" value="owner" checked="${'owner' in shown_fields or None}" />Owner
-            </label>
-            <label>
-                <input type="checkbox" name="backlog_fields" value="status" checked="${'status' in shown_fields or None}" />Status
-            </label>
-            <label>
-                <input type="checkbox" name="backlog_fields" value="time_created" checked="${'time_created' in shown_fields or None}" />Created
+            <label py:for="field in fields">
+                <input type="checkbox" name="backlog_fields" value="${field[0]}" checked="${field[0] in shown_fields or None}" />${field[1]}
             </label>
         </div>
     </body>

--- a/backlog/web_ui.py
+++ b/backlog/web_ui.py
@@ -11,7 +11,7 @@ from trac.core import *
 from trac.db import DatabaseManager
 from trac.env import IEnvironmentSetupParticipant
 from trac.perm import IPermissionRequestor
-from trac.ticket.api import ITicketChangeListener
+from trac.ticket.api import ITicketChangeListener, TicketSystem
 from trac.ticket.model import Ticket
 from trac.web.chrome import INavigationContributor, ITemplateProvider
 from trac.web.chrome import add_script, add_stylesheet
@@ -53,9 +53,9 @@ class BacklogPlugin(Component):
                IEnvironmentSetupParticipant, ITemplateProvider,
                ITicketChangeListener, IPermissionRequestor)
 
-    _ticket_fields = [ 
-        'id', 'summary', 'component', 'version', 'type', 'owner', 'status', 
-        'time_created'
+    _ticket_fields = [
+        u'id', u'summary', u'component', u'version', u'type', u'owner', u'status',
+        u'time_created'
     ]
 
     # IEnvironmentSetupParticipant
@@ -207,6 +207,7 @@ class BacklogPlugin(Component):
         data['form_token'] = req.form_token
         data['active_milestones'] = self._get_active_milestones(milestone)
         data['base_path'] = req.base_path
+        data['custom_fields'] = [(cf["name"], cf["label"]) for cf in TicketSystem(self.env).get_custom_fields()]
         data['shown_fields'] = req.session.get('backlog_fields') or self._ticket_fields
 
         if 'BACKLOG_ADMIN' in req.perm:


### PR DESCRIPTION
This is a pull request for the topic that I originally submitted as issue #9.

Custom fields do not show by default, and can be activated in the preferences pane for each user. This is something that may be worth to rethink in the future, as it may be useful to decide which fields should be shown by default when installing/configuring the plugin.

I tried making the code as DRY as possible, and took the chance to refactor a couple of details. I see more that can be improved, but I'd leave that for a future refactoring.
